### PR TITLE
Standardize image 1: TOGAF ADM End-to-End Reference Map

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,11 @@
 ## Diagrams
 
 ### 1. TOGAF ADM End-to-End Reference Map
-![TOGAF ADM End-to-End Reference Map](docs/diagrams/adm/togaf-adm-end-to-end-architecture.png)
+
+<p align="center">
+  <img src="docs/diagrams/adm/togaf-adm-end-to-end-architecture.png" alt="TOGAF ADM End-to-End Reference Map" width="90%"><br>
+  <em>TOGAF ADM End-to-End Reference Map</em>
+</p>
 
 ### 2. TOGAF ADM Cycle
 ![TOGAF ADM Cycle](docs/diagrams/adm/togaf-adm-cycle-v2.png)


### PR DESCRIPTION
Wraps the TOGAF ADM End-to-End Reference Map image in `<p align="center">`, converts to `<img>` tag with `width="90%"`, and adds an `<em>` caption per GitHub documentation best practices.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LcS4BieowQjjE65jGmm28U)_