### PR TITLE
Standardize image 2: TOGAF ADM Cycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,11 @@
 </p>
 
 ### 2. TOGAF ADM Cycle
-![TOGAF ADM Cycle](docs/diagrams/adm/togaf-adm-cycle-v2.png)
 
-*Previous version retained in the archive folder for traceability.*
+<p align="center">
+  <img src="docs/diagrams/adm/togaf-adm-cycle-v2.png" alt="TOGAF ADM Cycle" width="90%"><br>
+  <em>TOGAF ADM Cycle — Previous version retained in the archive folder for traceability.</em>
+</p>
 
 ### 3. Architecture Content Framework
 ![Architecture Content Framework](docs/diagrams/content-framework/architecture-content-framework-v2.png)


### PR DESCRIPTION
Wraps the TOGAF ADM Cycle image in `<p align="center">`, converts to `<img>` tag with `width="90%"`, and folds the adjacent traceability note into the `<em>` caption.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LcS4BieowQjjE65jGmm28U)_