### PR TITLE
Improve badge alt text to describe each link's purpose

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # TOGAF Diagrams
 
-[![GitHub stars](https://img.shields.io/github/stars/nelsambrose/togaf-diagrams?style=social)](https://github.com/nelsambrose/togaf-diagrams/stargazers)
-[![Last Commit](https://img.shields.io/github/last-commit/nelsambrose/togaf-diagrams)](https://github.com/nelsambrose/togaf-diagrams/commits/main)
-[![GitHub Pages](https://img.shields.io/badge/View%20Online-GitHub%20Pages-blue)](https://nelsambrose.github.io/togaf-diagrams/)
+[![GitHub Repository Star Count](https://img.shields.io/github/stars/nelsambrose/togaf-diagrams?style=social)](https://github.com/nelsambrose/togaf-diagrams/stargazers)
+[![Date of Last Repository Commit](https://img.shields.io/github/last-commit/nelsambrose/togaf-diagrams)](https://github.com/nelsambrose/togaf-diagrams/commits/main)
+[![View Diagrams Online via GitHub Pages](https://img.shields.io/badge/View%20Online-GitHub%20Pages-blue)](https://nelsambrose.github.io/togaf-diagrams/)
 
 > A free visual library of TOGAF architecture concepts — clear, simplified diagrams covering the ADM cycle, content framework, governance model, and more.
 


### PR DESCRIPTION
Updates the three GitHub badge alt texts to be descriptive of their link destinations rather than generic labels, improving accessibility for screen reader users.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LcS4BieowQjjE65jGmm28U)_