### PR TITLE
Replace diagram alt text with functional visual descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,56 +18,56 @@
 ### 1. TOGAF ADM End-to-End Reference Map
 
 <p align="center">
-  <img src="docs/diagrams/adm/togaf-adm-end-to-end-architecture.png" alt="TOGAF ADM End-to-End Reference Map" width="90%"><br>
+  <img src="docs/diagrams/adm/togaf-adm-end-to-end-architecture.png" alt="Horizontal swimlane diagram mapping all ADM phases with inputs, outputs, and cross-phase dependencies" width="90%"><br>
   <em>TOGAF ADM End-to-End Reference Map</em>
 </p>
 
 ### 2. TOGAF ADM Cycle
 
 <p align="center">
-  <img src="docs/diagrams/adm/togaf-adm-cycle-v2.png" alt="TOGAF ADM Cycle" width="90%"><br>
+  <img src="docs/diagrams/adm/togaf-adm-cycle-v2.png" alt="Circular flow diagram of ADM phases from Preliminary through H arranged around a central Requirements Management core" width="90%"><br>
   <em>TOGAF ADM Cycle — Previous version retained in the archive folder for traceability.</em>
 </p>
 
 ### 3. Architecture Content Framework
 
 <p align="center">
-  <img src="docs/diagrams/content-framework/architecture-content-framework-v2.png" alt="Architecture Content Framework" width="90%"><br>
+  <img src="docs/diagrams/content-framework/architecture-content-framework-v2.png" alt="Hierarchical framework diagram organizing architecture deliverables into metamodel categories, artifacts, and building blocks" width="90%"><br>
   <em>Architecture Content Framework</em>
 </p>
 
 ### 4. Enterprise Continuum & Architecture Repository
 
 <p align="center">
-  <img src="docs/diagrams/continuum/enterprise-continuum-architecture-repository-v2.png" alt="Enterprise Continuum & Architecture Repository" width="90%"><br>
+  <img src="docs/diagrams/continuum/enterprise-continuum-architecture-repository-v2.png" alt="Spectrum diagram positioning architecture assets from generic foundation architectures to organization-specific solutions, with repository classification layers" width="90%"><br>
   <em>Enterprise Continuum & Architecture Repository</em>
 </p>
 
 ### 5. Capability Assessment & Maturity Models
 
 <p align="center">
-  <img src="docs/diagrams/capability/capability-assessment-maturity-models-v2.png" alt="Capability Assessment & Maturity Models" width="90%"><br>
+  <img src="docs/diagrams/capability/capability-assessment-maturity-models-v2.png" alt="Grid-based maturity model rating architecture capabilities across defined levels from initial to optimising" width="90%"><br>
   <em>Capability Assessment & Maturity Models</em>
 </p>
 
 ### 6. Stakeholder Map with Views & Concerns
 
 <p align="center">
-  <img src="docs/diagrams/stakeholder/stakeholder-map-views-concerns-v2.png" alt="Stakeholder Map with Views and Concerns" width="90%"><br>
+  <img src="docs/diagrams/stakeholder/stakeholder-map-views-concerns-v2.png" alt="Matrix diagram mapping stakeholder roles to their relevant architecture views and primary concerns" width="90%"><br>
   <em>Stakeholder Map with Views & Concerns</em>
 </p>
 
 ### 7. Architecture Building Blocks vs. Solution Building Blocks
 
 <p align="center">
-  <img src="docs/diagrams/building-blocks/architecture-building-blocks-vs-solution-building-blocks.png" alt="Architecture Building Blocks vs. Solution Building Blocks" width="90%"><br>
+  <img src="docs/diagrams/building-blocks/architecture-building-blocks-vs-solution-building-blocks.png" alt="Side-by-side comparison diagram contrasting abstract architecture building blocks with vendor-specific solution building blocks" width="90%"><br>
   <em>Architecture Building Blocks vs. Solution Building Blocks</em>
 </p>
 
 ### 8. Architecture Governance Model
 
 <p align="center">
-  <img src="docs/diagrams/governance/architecture-governance-model-v2.png" alt="Architecture Governance Model" width="90%"><br>
+  <img src="docs/diagrams/governance/architecture-governance-model-v2.png" alt="Layered governance diagram showing oversight structures, compliance review boards, and accountability flows between architecture levels" width="90%"><br>
   <em>Architecture Governance Model</em>
 </p>
 


### PR DESCRIPTION
Replaces the 8 diagram `alt` attributes with brief functional descriptions of what each diagram visually represents, ensuring they are distinct from the `<em>` captions to avoid screen reader redundancy.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LcS4BieowQjjE65jGmm28U)_