### PR TITLE
Display diagrams 6 and 8 side by side in a two-column table

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,23 +91,34 @@ A comparison of abstract, reusable architecture building blocks against concrete
 </tr>
 </table>
 
+<table>
+<tr>
+<td width="50%" valign="top">
+
 ### 6. Stakeholder Map with Views & Concerns
 
 A mapping of key stakeholder roles to the architecture views and concerns most relevant to them, supporting targeted communication.
 
-<p align="center">
-  <img src="docs/diagrams/stakeholder/stakeholder-map-views-concerns-v2.png" alt="Matrix diagram mapping stakeholder roles to their relevant architecture views and primary concerns" width="90%"><br>
-  <em>Stakeholder Map with Views & Concerns</em>
-</p>
+</td>
+<td width="50%" valign="top">
 
 ### 8. Architecture Governance Model
 
 An overview of the governance structures, oversight bodies, and accountability mechanisms that ensure architecture compliance and quality.
 
-<p align="center">
-  <img src="docs/diagrams/governance/architecture-governance-model-v2.png" alt="Layered governance diagram showing oversight structures, compliance review boards, and accountability flows between architecture levels" width="90%"><br>
+</td>
+</tr>
+<tr>
+<td width="50%" align="center">
+  <img src="docs/diagrams/stakeholder/stakeholder-map-views-concerns-v2.png" alt="Matrix diagram mapping stakeholder roles to their relevant architecture views and primary concerns" width="100%"><br>
+  <em>Stakeholder Map with Views & Concerns</em>
+</td>
+<td width="50%" align="center">
+  <img src="docs/diagrams/governance/architecture-governance-model-v2.png" alt="Layered governance diagram showing oversight structures, compliance review boards, and accountability flows between architecture levels" width="100%"><br>
   <em>Architecture Governance Model</em>
-</p>
+</td>
+</tr>
+</table>
 
 ## Contributing
 


### PR DESCRIPTION
Displays diagrams 6 (Stakeholder Map) and 8 (Architecture Governance Model) side by side in a two-column HTML table, matching the pattern used for the other paired diagrams.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LcS4BieowQjjE65jGmm28U)_