### PR TITLE
Fix top gap in diagrams 6 & 8 table by aligning images to top

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,11 +109,11 @@ An overview of the governance structures, oversight bodies, and accountability m
 </td>
 </tr>
 <tr>
-<td width="50%" align="center">
+<td width="50%" align="center" valign="top">
   <img src="docs/diagrams/stakeholder/stakeholder-map-views-concerns-v2.png" alt="Matrix diagram mapping stakeholder roles to their relevant architecture views and primary concerns" width="100%"><br>
   <em>Stakeholder Map with Views & Concerns</em>
 </td>
-<td width="50%" align="center">
+<td width="50%" align="center" valign="top">
   <img src="docs/diagrams/governance/architecture-governance-model-v2.png" alt="Layered governance diagram showing oversight structures, compliance review boards, and accountability flows between architecture levels" width="100%"><br>
   <em>Architecture Governance Model</em>
 </td>


### PR DESCRIPTION
Adds `valign="top"` to the image row cells in the diagrams 6 & 8 table so both images anchor to the top of their cells, eliminating the blank gap that appears when one image is taller than the other.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LcS4BieowQjjE65jGmm28U)_