### PR TITLE
Fix README paths after phase-prefix renames (continuum, building-blocks, governance)

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ A classification system for architecture assets ranging from generic foundation 
   <em>Architecture Content Framework</em>
 </td>
 <td width="50%" align="center">
-  <img src="docs/diagrams/continuum/enterprise-continuum-architecture-repository-v2.png" alt="Spectrum diagram positioning architecture assets from generic foundation architectures to organization-specific solutions, with repository classification layers" width="100%"><br>
+  <img src="docs/diagrams/continuum/phase-a-enterprise-continuum-architecture-repository-v2.png" alt="Spectrum diagram positioning architecture assets from generic foundation architectures to organization-specific solutions, with repository classification layers" width="100%"><br>
   <em>Enterprise Continuum & Architecture Repository</em>
 </td>
 </tr>
@@ -85,7 +85,7 @@ A comparison of abstract, reusable architecture building blocks against concrete
   <em>Capability Assessment & Maturity Models</em>
 </td>
 <td width="50%" align="center" valign="top">
-  <img src="docs/diagrams/building-blocks/architecture-building-blocks-vs-solution-building-blocks-v2.png" alt="Side-by-side comparison diagram contrasting abstract architecture building blocks with vendor-specific solution building blocks" width="100%"><br>
+  <img src="docs/diagrams/building-blocks/phase-a-architecture-building-blocks-vs-solution-building-blocks-v2.png" alt="Side-by-side comparison diagram contrasting abstract architecture building blocks with vendor-specific solution building blocks" width="100%"><br>
   <em>Architecture Building Blocks vs. Solution Building Blocks</em>
 </td>
 </tr>
@@ -114,7 +114,7 @@ An overview of the governance structures, oversight bodies, and accountability m
   <em>Stakeholder Map with Views & Concerns</em>
 </td>
 <td width="50%" align="center" valign="top">
-  <img src="docs/diagrams/governance/architecture-governance-model-v2.png" alt="Layered governance diagram showing oversight structures, compliance review boards, and accountability flows between architecture levels" width="100%"><br>
+  <img src="docs/diagrams/governance/phase-a-architecture-governance-model-v2.png" alt="Layered governance diagram showing oversight structures, compliance review boards, and accountability flows between architecture levels" width="100%"><br>
   <em>Architecture Governance Model</em>
 </td>
 </tr>


### PR DESCRIPTION
Updates three broken README image paths to match the renamed files: `enterprise-continuum-architecture-repository-v2.png` → `phase-a-...`, `architecture-building-blocks-vs-solution-building-blocks-v2.png` → `phase-a-...`, and `architecture-governance-model-v2.png` → `phase-a-...`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LcS4BieowQjjE65jGmm28U)_