### PR TITLE
Add TOGAF Architecture Repository diagram to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,24 @@ In Phase A (Architecture Vision), Business Scenarios are used to identify and ar
 <tr>
 <td valign="top">
 
+### 10. TOGAF Architecture Repository
+
+A visual overview of the TOGAF Architecture Repository showing governance assets, standards, reusable architecture knowledge, capability structures, and repository consumers supporting enterprise architecture operations.
+
+</td>
+</tr>
+<tr>
+<td align="center">
+  <img src="docs/diagrams/repository/architecture-repository.png" alt="Diagram of the TOGAF Architecture Repository showing governance assets, standards, reusable architecture knowledge, capability structures, and repository consumers" width="90%"><br>
+  <em>TOGAF Architecture Repository</em>
+</td>
+</tr>
+</table>
+
+<table>
+<tr>
+<td valign="top">
+
 ### D. TOGAF Technology Architecture
 
 A layered view of TOGAF Technology Architecture showing infrastructure foundations, platform services, integration capabilities, security architecture, operational resilience, and key technology outputs.


### PR DESCRIPTION
## Summary

- Adds diagram entry **10. TOGAF Architecture Repository** to README
- Links to the existing image at `docs/diagrams/repository/architecture-repository.png`
- Follows the same full-width table layout used by surrounding entries
- No files moved or renamed; README-only change

## Test plan
- [ ] README renders the new diagram correctly at entry 10
- [ ] No other sections are affected

https://claude.ai/code/session_01EZ5nYXnhFqp7jZUEMhcSM7

---
_Generated by [Claude Code](https://claude.ai/code/session_01EZ5nYXnhFqp7jZUEMhcSM7)_