### PR TITLE
Add TOGAF Architecture Landscape diagram as section 11

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,24 @@ A visual overview of the TOGAF Architecture Repository showing governance assets
 <tr>
 <td valign="top">
 
+### 11. TOGAF Architecture Landscape
+
+A structured view of enterprise architecture assets across strategic, segment, and capability levels, supporting governance, reuse, planning, and architecture evolution.
+
+</td>
+</tr>
+<tr>
+<td align="center">
+  <img src="docs/diagrams/repository/architecture-landscape.png" alt="Diagram showing enterprise architecture assets organised across strategic, segment, and capability levels with links to governance, reuse, and planning" width="90%"><br>
+  <em>TOGAF Architecture Landscape</em>
+</td>
+</tr>
+</table>
+
+<table>
+<tr>
+<td valign="top">
+
 ### D. TOGAF Technology Architecture
 
 A layered view of TOGAF Technology Architecture showing infrastructure foundations, platform services, integration capabilities, security architecture, operational resilience, and key technology outputs.


### PR DESCRIPTION
## Summary

- Adds **11. TOGAF Architecture Landscape** to README between section 10 (Architecture Repository) and section D (Technology Architecture)
- Links to existing image at `docs/diagrams/repository/architecture-landscape.png`
- README-only change; no files moved or renamed

## Test plan
- [ ] README renders the new diagram at section 11 in the correct position
- [ ] Sections 10 and D are unaffected

https://claude.ai/code/session_01EZ5nYXnhFqp7jZUEMhcSM7

---
_Generated by [Claude Code](https://claude.ai/code/session_01EZ5nYXnhFqp7jZUEMhcSM7)_