### PR TITLE
Add TOGAF Governance Log diagram as section 13

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,24 @@ A visual overview of the TOGAF Standards Information Base showing approved enter
 <tr>
 <td valign="top">
 
+### 13. TOGAF Governance Log
+
+A visual overview of the TOGAF Governance Log showing architecture decisions, compliance activities, governance oversight, risk and exception management, audit traceability, and continuous governance evolution supporting enterprise accountability and compliance.
+
+</td>
+</tr>
+<tr>
+<td align="center">
+  <img src="docs/diagrams/repository/governance-log.png" alt="Diagram of the TOGAF Governance Log showing architecture decisions, compliance activities, governance oversight, risk and exception management, audit traceability, and continuous governance evolution" width="90%"><br>
+  <em>TOGAF Governance Log</em>
+</td>
+</tr>
+</table>
+
+<table>
+<tr>
+<td valign="top">
+
 ### D. TOGAF Technology Architecture
 
 A layered view of TOGAF Technology Architecture showing infrastructure foundations, platform services, integration capabilities, security architecture, operational resilience, and key technology outputs.


### PR DESCRIPTION
## Summary

- Adds **13. TOGAF Governance Log** to README between section 12 (Standards Information Base) and section D (Technology Architecture)
- Links to existing image at `docs/diagrams/repository/governance-log.png`
- README-only change

## Test plan
- [ ] README renders section 13 in the correct position between 12 and D
- [ ] Surrounding sections unaffected

https://claude.ai/code/session_01EZ5nYXnhFqp7jZUEMhcSM7

---
_Generated by [Claude Code](https://claude.ai/code/session_01EZ5nYXnhFqp7jZUEMhcSM7)_