### PR TITLE
Add TOGAF Architecture Compliance Reviews diagram as section 16

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,24 @@ A visual overview of TOGAF Architecture Contracts showing governance agreements,
 <tr>
 <td valign="top">
 
+### 16. TOGAF Architecture Compliance Reviews
+
+A visual overview of TOGAF Architecture Compliance Reviews showing how enterprise solutions are assessed against architecture principles, standards, governance requirements, risks, and compliance obligations to ensure alignment and delivery readiness.
+
+</td>
+</tr>
+<tr>
+<td align="center">
+  <img src="docs/diagrams/governance/architecture-compliance-reviews.png" alt="Diagram of TOGAF Architecture Compliance Reviews showing assessment of solutions against architecture principles, standards, governance requirements, risks, and compliance obligations" width="90%"><br>
+  <em>TOGAF Architecture Compliance Reviews</em>
+</td>
+</tr>
+</table>
+
+<table>
+<tr>
+<td valign="top">
+
 ### D. TOGAF Technology Architecture
 
 A layered view of TOGAF Technology Architecture showing infrastructure foundations, platform services, integration capabilities, security architecture, operational resilience, and key technology outputs.


### PR DESCRIPTION
## Summary

- Adds **16. TOGAF Architecture Compliance Reviews** to README between section 15 (Architecture Contracts) and section D (Technology Architecture)
- Links to existing image at `docs/diagrams/governance/architecture-compliance-reviews.png`
- README-only change

## Test plan
- [ ] Section 16 renders correctly between 15 and D
- [ ] Surrounding sections unaffected

https://claude.ai/code/session_01EZ5nYXnhFqp7jZUEMhcSM7

---
_Generated by [Claude Code](https://claude.ai/code/session_01EZ5nYXnhFqp7jZUEMhcSM7)_