### PR TITLE
Insert TOGAF Architecture Capability as section 18, renumber 18-19 to 19-20

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,7 +286,25 @@ A visual overview of TOGAF Architecture Principles showing how business, data, a
 <tr>
 <td valign="top">
 
-### 18. TOGAF Architecture Contracts
+### 18. TOGAF Architecture Capability
+
+A visual overview of TOGAF Architecture Capability showing the governance structures, people, processes, tools, repository support, maturity practices, and continuous improvement mechanisms required to develop, govern, and sustain enterprise architecture across the organization.
+
+</td>
+</tr>
+<tr>
+<td align="center">
+  <img src="docs/diagrams/capability/architecture-capability.png" alt="Diagram of TOGAF Architecture Capability showing governance structures, people, processes, tools, repository support, maturity practices, and continuous improvement mechanisms for enterprise architecture" width="90%"><br>
+  <em>TOGAF Architecture Capability</em>
+</td>
+</tr>
+</table>
+
+<table>
+<tr>
+<td valign="top">
+
+### 19. TOGAF Architecture Contracts
 
 A visual overview of TOGAF Architecture Contracts showing governance agreements, architecture expectations, compliance obligations, responsibilities, delivery alignment, risk and exception management, and implementation accountability across the enterprise.
 
@@ -304,7 +322,7 @@ A visual overview of TOGAF Architecture Contracts showing governance agreements,
 <tr>
 <td valign="top">
 
-### 19. TOGAF Architecture Compliance Reviews
+### 20. TOGAF Architecture Compliance Reviews
 
 A visual overview of TOGAF Architecture Compliance Reviews showing how enterprise solutions are assessed against architecture principles, standards, governance requirements, risks, and compliance obligations to ensure alignment and delivery readiness.
 


### PR DESCRIPTION
## Summary

- Inserts **18. TOGAF Architecture Capability** between section 17 (Architecture Principles) and section 19 (Architecture Contracts)
- Links to `docs/diagrams/capability/architecture-capability.png`
- Renumbers former sections 18–19 to 19–20
- README-only change

## Test plan
- [ ] Section 18 renders correctly between 17 and 19
- [ ] Sections 19–20 and lettered sections are unaffected

https://claude.ai/code/session_01EZ5nYXnhFqp7jZUEMhcSM7

---
_Generated by [Claude Code](https://claude.ai/code/session_01EZ5nYXnhFqp7jZUEMhcSM7)_