### PR TITLE
Add TOGAF Requirements Management as section 23

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,6 +376,24 @@ A centralized governance repository that stores architecture decisions, complian
 <tr>
 <td valign="top">
 
+### 23. TOGAF Requirements Management
+
+A continuous process that captures, validates, prioritizes, manages, and governs architecture requirements across all ADM phases to ensure alignment with business objectives and solution delivery.
+
+</td>
+</tr>
+<tr>
+<td align="center">
+  <img src="docs/diagrams/governance/requirements-management.png" alt="Diagram of TOGAF Requirements Management showing the continuous process of capturing, validating, prioritising, managing, and governing architecture requirements across all ADM phases" width="90%"><br>
+  <em>TOGAF Requirements Management</em>
+</td>
+</tr>
+</table>
+
+<table>
+<tr>
+<td valign="top">
+
 ### D. TOGAF Technology Architecture
 
 A layered view of TOGAF Technology Architecture showing infrastructure foundations, platform services, integration capabilities, security architecture, operational resilience, and key technology outputs.


### PR DESCRIPTION
## Summary

- Adds **23. TOGAF Requirements Management** after section 22 (Governance Repository) and before section D (Technology Architecture)
- Links to `docs/diagrams/governance/requirements-management.png`
- Sits in the governance cluster alongside Principles, Capability, Contracts, Compliance Reviews, and Governance Repository
- README-only change

## Test plan
- [ ] Section 23 renders correctly between 22 and D
- [ ] Surrounding sections unaffected

https://claude.ai/code/session_01EZ5nYXnhFqp7jZUEMhcSM7

---
_Generated by [Claude Code](https://claude.ai/code/session_01EZ5nYXnhFqp7jZUEMhcSM7)_