### PR TITLE
Insert TOGAF Architecture Vision as section 10, renumber 10-23 to 11-24

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,25 @@ In Phase A (Architecture Vision), Business Scenarios are used to identify and ar
 <tr>
 <td valign="top">
 
-### 10. TOGAF Architecture Repository
+### 10. TOGAF Architecture Vision
+
+Defines the high-level aspirational target architecture, stakeholder alignment, business value, scope, and transformation objectives that guide the enterprise architecture initiative.
+
+</td>
+</tr>
+<tr>
+<td align="center">
+  <img src="docs/diagrams/adm/architecture-vision.png" alt="Diagram of TOGAF Architecture Vision showing the high-level aspirational target architecture, stakeholder alignment, business value, scope, and transformation objectives" width="90%"><br>
+  <em>TOGAF Architecture Vision</em>
+</td>
+</tr>
+</table>
+
+<table>
+<tr>
+<td valign="top">
+
+### 11. TOGAF Architecture Repository
 
 A visual overview of the TOGAF Architecture Repository showing governance assets, standards, reusable architecture knowledge, capability structures, and repository consumers supporting enterprise architecture operations.
 
@@ -160,7 +178,7 @@ A visual overview of the TOGAF Architecture Repository showing governance assets
 <tr>
 <td valign="top">
 
-### 11. TOGAF Architecture Landscape
+### 12. TOGAF Architecture Landscape
 
 A structured view of enterprise architecture assets across strategic, segment, and capability levels, supporting governance, reuse, planning, and architecture evolution.
 
@@ -178,7 +196,7 @@ A structured view of enterprise architecture assets across strategic, segment, a
 <tr>
 <td valign="top">
 
-### 12. TOGAF Enterprise Continuum
+### 13. TOGAF Enterprise Continuum
 
 A visual overview of the TOGAF Enterprise Continuum showing how reusable architecture assets evolve from generic foundation architectures to organization-specific enterprise solutions, enabling standardization, governance alignment, reuse, and architecture consistency across the enterprise.
 
@@ -196,7 +214,7 @@ A visual overview of the TOGAF Enterprise Continuum showing how reusable archite
 <tr>
 <td valign="top">
 
-### 13. TOGAF Reference Architectures
+### 14. TOGAF Reference Architectures
 
 Reusable architecture models, standards, patterns, and implementation guidance that accelerate solution delivery, improve consistency, and support enterprise governance across the enterprise.
 
@@ -214,7 +232,7 @@ Reusable architecture models, standards, patterns, and implementation guidance t
 <tr>
 <td valign="top">
 
-### 14. TOGAF Architecture Building Blocks (ABBs)
+### 15. TOGAF Architecture Building Blocks (ABBs)
 
 A visual overview of TOGAF Architecture Building Blocks (ABBs) showing how reusable logical architecture capabilities, standards, services, and governance models define enterprise architecture intent and guide the realization of Solution Building Blocks and enterprise solutions.
 
@@ -232,7 +250,7 @@ A visual overview of TOGAF Architecture Building Blocks (ABBs) showing how reusa
 <tr>
 <td valign="top">
 
-### 15. TOGAF Solution Building Blocks (SBBs)
+### 16. TOGAF Solution Building Blocks (SBBs)
 
 A visual overview of TOGAF Solution Building Blocks (SBBs) showing how reusable technology components, platforms, integrations, operational services, and governance capabilities implement enterprise architecture solutions and enable standardized, scalable delivery.
 
@@ -250,7 +268,7 @@ A visual overview of TOGAF Solution Building Blocks (SBBs) showing how reusable 
 <tr>
 <td valign="top">
 
-### 16. Standards Information Base
+### 17. Standards Information Base
 
 A visual overview of the TOGAF Standards Information Base showing approved enterprise standards, technology policies, security controls, compliance requirements, governance lifecycle, and consumers who use standards to support architecture consistency and enterprise compliance.
 
@@ -268,7 +286,7 @@ A visual overview of the TOGAF Standards Information Base showing approved enter
 <tr>
 <td valign="top">
 
-### 17. TOGAF Governance Log
+### 18. TOGAF Governance Log
 
 A visual overview of the TOGAF Governance Log showing architecture decisions, compliance activities, governance oversight, risk and exception management, audit traceability, and continuous governance evolution supporting enterprise accountability and compliance.
 
@@ -286,7 +304,7 @@ A visual overview of the TOGAF Governance Log showing architecture decisions, co
 <tr>
 <td valign="top">
 
-### 18. TOGAF Architecture Principles
+### 19. TOGAF Architecture Principles
 
 A visual overview of TOGAF Architecture Principles showing how business, data, application, technology, and governance principles guide enterprise decision-making, standards alignment, architecture quality, and consistent solution delivery.
 
@@ -304,7 +322,7 @@ A visual overview of TOGAF Architecture Principles showing how business, data, a
 <tr>
 <td valign="top">
 
-### 19. TOGAF Architecture Capability
+### 20. TOGAF Architecture Capability
 
 A visual overview of TOGAF Architecture Capability showing the governance structures, people, processes, tools, repository support, maturity practices, and continuous improvement mechanisms required to develop, govern, and sustain enterprise architecture across the organization.
 
@@ -322,7 +340,7 @@ A visual overview of TOGAF Architecture Capability showing the governance struct
 <tr>
 <td valign="top">
 
-### 20. TOGAF Architecture Contracts
+### 21. TOGAF Architecture Contracts
 
 A visual overview of TOGAF Architecture Contracts showing governance agreements, architecture expectations, compliance obligations, responsibilities, delivery alignment, risk and exception management, and implementation accountability across the enterprise.
 
@@ -340,7 +358,7 @@ A visual overview of TOGAF Architecture Contracts showing governance agreements,
 <tr>
 <td valign="top">
 
-### 21. TOGAF Architecture Compliance Reviews
+### 22. TOGAF Architecture Compliance Reviews
 
 A visual overview of TOGAF Architecture Compliance Reviews showing how enterprise solutions are assessed against architecture principles, standards, governance requirements, risks, and compliance obligations to ensure alignment and delivery readiness.
 
@@ -358,7 +376,7 @@ A visual overview of TOGAF Architecture Compliance Reviews showing how enterpris
 <tr>
 <td valign="top">
 
-### 22. TOGAF Governance Repository
+### 23. TOGAF Governance Repository
 
 A centralized governance repository that stores architecture decisions, compliance records, policies, audit evidence, approvals, and governance outcomes supporting enterprise accountability, traceability, and regulatory alignment.
 
@@ -376,7 +394,7 @@ A centralized governance repository that stores architecture decisions, complian
 <tr>
 <td valign="top">
 
-### 23. TOGAF Requirements Management
+### 24. TOGAF Requirements Management
 
 A continuous process that captures, validates, prioritizes, manages, and governs architecture requirements across all ADM phases to ensure alignment with business objectives and solution delivery.
 


### PR DESCRIPTION
## Summary

- Inserts **10. TOGAF Architecture Vision** directly after section 9 (Business Scenarios), both being Phase A ADM artifacts
- Links to `docs/diagrams/adm/architecture-vision.png`
- Renumbers former sections 10–23 to 11–24 accordingly
- README-only change

## Test plan
- [ ] Section 10 renders correctly after Business Scenarios (9) and before Architecture Repository (11)
- [ ] Sections 11–24 and lettered sections are unaffected

https://claude.ai/code/session_01EZ5nYXnhFqp7jZUEMhcSM7

---
_Generated by [Claude Code](https://claude.ai/code/session_01EZ5nYXnhFqp7jZUEMhcSM7)_