### PR TITLE
Insert TOGAF Stakeholder Management as section 11, renumber 11-24 to 12-25

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,25 @@ Defines the high-level aspirational target architecture, stakeholder alignment, 
 <tr>
 <td valign="top">
 
-### 11. TOGAF Architecture Repository
+### 11. TOGAF Stakeholder Management
+
+A structured approach for identifying, analyzing, engaging, and governing stakeholders to ensure enterprise architecture alignment, communication effectiveness, and successful transformation outcomes.
+
+</td>
+</tr>
+<tr>
+<td align="center">
+  <img src="docs/diagrams/stakeholder/stakeholder-management.png" alt="Diagram of TOGAF Stakeholder Management showing a structured approach for identifying, analysing, engaging, and governing stakeholders to support architecture alignment and transformation success" width="90%"><br>
+  <em>TOGAF Stakeholder Management</em>
+</td>
+</tr>
+</table>
+
+<table>
+<tr>
+<td valign="top">
+
+### 12. TOGAF Architecture Repository
 
 A visual overview of the TOGAF Architecture Repository showing governance assets, standards, reusable architecture knowledge, capability structures, and repository consumers supporting enterprise architecture operations.
 
@@ -178,7 +196,7 @@ A visual overview of the TOGAF Architecture Repository showing governance assets
 <tr>
 <td valign="top">
 
-### 12. TOGAF Architecture Landscape
+### 13. TOGAF Architecture Landscape
 
 A structured view of enterprise architecture assets across strategic, segment, and capability levels, supporting governance, reuse, planning, and architecture evolution.
 
@@ -196,7 +214,7 @@ A structured view of enterprise architecture assets across strategic, segment, a
 <tr>
 <td valign="top">
 
-### 13. TOGAF Enterprise Continuum
+### 14. TOGAF Enterprise Continuum
 
 A visual overview of the TOGAF Enterprise Continuum showing how reusable architecture assets evolve from generic foundation architectures to organization-specific enterprise solutions, enabling standardization, governance alignment, reuse, and architecture consistency across the enterprise.
 
@@ -214,7 +232,7 @@ A visual overview of the TOGAF Enterprise Continuum showing how reusable archite
 <tr>
 <td valign="top">
 
-### 14. TOGAF Reference Architectures
+### 15. TOGAF Reference Architectures
 
 Reusable architecture models, standards, patterns, and implementation guidance that accelerate solution delivery, improve consistency, and support enterprise governance across the enterprise.
 
@@ -232,7 +250,7 @@ Reusable architecture models, standards, patterns, and implementation guidance t
 <tr>
 <td valign="top">
 
-### 15. TOGAF Architecture Building Blocks (ABBs)
+### 16. TOGAF Architecture Building Blocks (ABBs)
 
 A visual overview of TOGAF Architecture Building Blocks (ABBs) showing how reusable logical architecture capabilities, standards, services, and governance models define enterprise architecture intent and guide the realization of Solution Building Blocks and enterprise solutions.
 
@@ -250,7 +268,7 @@ A visual overview of TOGAF Architecture Building Blocks (ABBs) showing how reusa
 <tr>
 <td valign="top">
 
-### 16. TOGAF Solution Building Blocks (SBBs)
+### 17. TOGAF Solution Building Blocks (SBBs)
 
 A visual overview of TOGAF Solution Building Blocks (SBBs) showing how reusable technology components, platforms, integrations, operational services, and governance capabilities implement enterprise architecture solutions and enable standardized, scalable delivery.
 
@@ -268,7 +286,7 @@ A visual overview of TOGAF Solution Building Blocks (SBBs) showing how reusable 
 <tr>
 <td valign="top">
 
-### 17. Standards Information Base
+### 18. Standards Information Base
 
 A visual overview of the TOGAF Standards Information Base showing approved enterprise standards, technology policies, security controls, compliance requirements, governance lifecycle, and consumers who use standards to support architecture consistency and enterprise compliance.
 
@@ -286,7 +304,7 @@ A visual overview of the TOGAF Standards Information Base showing approved enter
 <tr>
 <td valign="top">
 
-### 18. TOGAF Governance Log
+### 19. TOGAF Governance Log
 
 A visual overview of the TOGAF Governance Log showing architecture decisions, compliance activities, governance oversight, risk and exception management, audit traceability, and continuous governance evolution supporting enterprise accountability and compliance.
 
@@ -304,7 +322,7 @@ A visual overview of the TOGAF Governance Log showing architecture decisions, co
 <tr>
 <td valign="top">
 
-### 19. TOGAF Architecture Principles
+### 20. TOGAF Architecture Principles
 
 A visual overview of TOGAF Architecture Principles showing how business, data, application, technology, and governance principles guide enterprise decision-making, standards alignment, architecture quality, and consistent solution delivery.
 
@@ -322,7 +340,7 @@ A visual overview of TOGAF Architecture Principles showing how business, data, a
 <tr>
 <td valign="top">
 
-### 20. TOGAF Architecture Capability
+### 21. TOGAF Architecture Capability
 
 A visual overview of TOGAF Architecture Capability showing the governance structures, people, processes, tools, repository support, maturity practices, and continuous improvement mechanisms required to develop, govern, and sustain enterprise architecture across the organization.
 
@@ -340,7 +358,7 @@ A visual overview of TOGAF Architecture Capability showing the governance struct
 <tr>
 <td valign="top">
 
-### 21. TOGAF Architecture Contracts
+### 22. TOGAF Architecture Contracts
 
 A visual overview of TOGAF Architecture Contracts showing governance agreements, architecture expectations, compliance obligations, responsibilities, delivery alignment, risk and exception management, and implementation accountability across the enterprise.
 
@@ -358,7 +376,7 @@ A visual overview of TOGAF Architecture Contracts showing governance agreements,
 <tr>
 <td valign="top">
 
-### 22. TOGAF Architecture Compliance Reviews
+### 23. TOGAF Architecture Compliance Reviews
 
 A visual overview of TOGAF Architecture Compliance Reviews showing how enterprise solutions are assessed against architecture principles, standards, governance requirements, risks, and compliance obligations to ensure alignment and delivery readiness.
 
@@ -376,7 +394,7 @@ A visual overview of TOGAF Architecture Compliance Reviews showing how enterpris
 <tr>
 <td valign="top">
 
-### 23. TOGAF Governance Repository
+### 24. TOGAF Governance Repository
 
 A centralized governance repository that stores architecture decisions, compliance records, policies, audit evidence, approvals, and governance outcomes supporting enterprise accountability, traceability, and regulatory alignment.
 
@@ -394,7 +412,7 @@ A centralized governance repository that stores architecture decisions, complian
 <tr>
 <td valign="top">
 
-### 24. TOGAF Requirements Management
+### 25. TOGAF Requirements Management
 
 A continuous process that captures, validates, prioritizes, manages, and governs architecture requirements across all ADM phases to ensure alignment with business objectives and solution delivery.
 


### PR DESCRIPTION
## Summary

- Inserts **11. TOGAF Stakeholder Management** directly after section 10 (Architecture Vision), grouping it with Phase A ADM artifacts
- Links to `docs/diagrams/stakeholder/stakeholder-management.png`
- Renumbers former sections 11–24 to 12–25 accordingly
- README-only change

## Test plan
- [ ] Section 11 renders correctly between Architecture Vision (10) and Architecture Repository (12)
- [ ] Sections 12–25 and lettered sections are unaffected

https://claude.ai/code/session_01EZ5nYXnhFqp7jZUEMhcSM7

---
_Generated by [Claude Code](https://claude.ai/code/session_01EZ5nYXnhFqp7jZUEMhcSM7)_