### PR TITLE
Add TOGAF Architecture Partitioning diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,7 +352,25 @@ A visual overview of the TOGAF Architecture Metamodel showing the structural rel
 <tr>
 <td valign="top">
 
-### 21. TOGAF Architecture Landscape
+### 21. TOGAF Architecture Partitioning
+
+A visual overview of TOGAF Architecture Partitioning showing how enterprise architectures are separated across strategic, segment, capability, business unit, and solution levels to support governance, scalability, reuse, and controlled transformation.
+
+</td>
+</tr>
+<tr>
+<td align="center">
+  <img src="docs/diagrams/architecture/architecture-partitioning.png" alt="Diagram of TOGAF Architecture Partitioning showing how enterprise architectures are separated across strategic, segment, capability, business unit, and solution levels to support governance, scalability, reuse, and controlled transformation" width="90%"><br>
+  <em>TOGAF Architecture Partitioning</em>
+</td>
+</tr>
+</table>
+
+<table>
+<tr>
+<td valign="top">
+
+### 22. TOGAF Architecture Landscape
 
 A structured view of enterprise architecture assets across strategic, segment, and capability levels, supporting governance, reuse, planning, and architecture evolution.
 
@@ -370,7 +388,7 @@ A structured view of enterprise architecture assets across strategic, segment, a
 <tr>
 <td valign="top">
 
-### 22. TOGAF Enterprise Continuum
+### 23. TOGAF Enterprise Continuum
 
 A visual overview of the TOGAF Enterprise Continuum showing how reusable architecture assets evolve from generic foundation architectures to organization-specific enterprise solutions, enabling standardization, governance alignment, reuse, and architecture consistency across the enterprise.
 
@@ -388,7 +406,7 @@ A visual overview of the TOGAF Enterprise Continuum showing how reusable archite
 <tr>
 <td valign="top">
 
-### 23. TOGAF Reference Architectures
+### 24. TOGAF Reference Architectures
 
 Reusable architecture models, standards, patterns, and implementation guidance that accelerate solution delivery, improve consistency, and support enterprise governance across the enterprise.
 
@@ -406,7 +424,7 @@ Reusable architecture models, standards, patterns, and implementation guidance t
 <tr>
 <td valign="top">
 
-### 24. TOGAF Architecture Building Blocks (ABBs)
+### 25. TOGAF Architecture Building Blocks (ABBs)
 
 A visual overview of TOGAF Architecture Building Blocks (ABBs) showing how reusable logical architecture capabilities, standards, services, and governance models define enterprise architecture intent and guide the realization of Solution Building Blocks and enterprise solutions.
 
@@ -424,7 +442,7 @@ A visual overview of TOGAF Architecture Building Blocks (ABBs) showing how reusa
 <tr>
 <td valign="top">
 
-### 25. TOGAF Solution Building Blocks (SBBs)
+### 26. TOGAF Solution Building Blocks (SBBs)
 
 A visual overview of TOGAF Solution Building Blocks (SBBs) showing how reusable technology components, platforms, integrations, operational services, and governance capabilities implement enterprise architecture solutions and enable standardized, scalable delivery.
 
@@ -442,7 +460,7 @@ A visual overview of TOGAF Solution Building Blocks (SBBs) showing how reusable 
 <tr>
 <td valign="top">
 
-### 26. Standards Information Base
+### 27. Standards Information Base
 
 A visual overview of the TOGAF Standards Information Base showing approved enterprise standards, technology policies, security controls, compliance requirements, governance lifecycle, and consumers who use standards to support architecture consistency and enterprise compliance.
 
@@ -460,7 +478,7 @@ A visual overview of the TOGAF Standards Information Base showing approved enter
 <tr>
 <td valign="top">
 
-### 27. TOGAF Governance Log
+### 28. TOGAF Governance Log
 
 A visual overview of the TOGAF Governance Log showing architecture decisions, compliance activities, governance oversight, risk and exception management, audit traceability, and continuous governance evolution supporting enterprise accountability and compliance.
 
@@ -478,7 +496,7 @@ A visual overview of the TOGAF Governance Log showing architecture decisions, co
 <tr>
 <td valign="top">
 
-### 28. TOGAF Architecture Principles
+### 29. TOGAF Architecture Principles
 
 A visual overview of TOGAF Architecture Principles showing how business, data, application, technology, and governance principles guide enterprise decision-making, standards alignment, architecture quality, and consistent solution delivery.
 
@@ -496,7 +514,7 @@ A visual overview of TOGAF Architecture Principles showing how business, data, a
 <tr>
 <td valign="top">
 
-### 29. TOGAF Architecture Capability
+### 30. TOGAF Architecture Capability
 
 A visual overview of TOGAF Architecture Capability showing the governance structures, people, processes, tools, repository support, maturity practices, and continuous improvement mechanisms required to develop, govern, and sustain enterprise architecture across the organization.
 
@@ -514,7 +532,7 @@ A visual overview of TOGAF Architecture Capability showing the governance struct
 <tr>
 <td valign="top">
 
-### 30. TOGAF Architecture Contracts
+### 31. TOGAF Architecture Contracts
 
 A visual overview of TOGAF Architecture Contracts showing governance agreements, architecture expectations, compliance obligations, responsibilities, delivery alignment, risk and exception management, and implementation accountability across the enterprise.
 
@@ -532,7 +550,7 @@ A visual overview of TOGAF Architecture Contracts showing governance agreements,
 <tr>
 <td valign="top">
 
-### 31. TOGAF Architecture Compliance Reviews
+### 32. TOGAF Architecture Compliance Reviews
 
 A visual overview of TOGAF Architecture Compliance Reviews showing how enterprise solutions are assessed against architecture principles, standards, governance requirements, risks, and compliance obligations to ensure alignment and delivery readiness.
 
@@ -550,7 +568,7 @@ A visual overview of TOGAF Architecture Compliance Reviews showing how enterpris
 <tr>
 <td valign="top">
 
-### 32. TOGAF Governance Repository
+### 33. TOGAF Governance Repository
 
 A centralized governance repository that stores architecture decisions, compliance records, policies, audit evidence, approvals, and governance outcomes supporting enterprise accountability, traceability, and regulatory alignment.
 
@@ -568,7 +586,7 @@ A centralized governance repository that stores architecture decisions, complian
 <tr>
 <td valign="top">
 
-### 33. TOGAF Risk Management
+### 34. TOGAF Risk Management
 
 A visual overview of TOGAF Risk Management showing how enterprise architecture risks are identified, assessed, governed, mitigated, and continuously monitored across transformation initiatives and ADM activities.
 
@@ -586,7 +604,7 @@ A visual overview of TOGAF Risk Management showing how enterprise architecture r
 <tr>
 <td valign="top">
 
-### 34. TOGAF Security Architecture Integration
+### 35. TOGAF Security Architecture Integration
 
 A visual overview of TOGAF Security Architecture Integration showing how security controls, governance, compliance, resilience, and risk management are embedded across business, data, application, and technology architecture domains.
 
@@ -604,7 +622,7 @@ A visual overview of TOGAF Security Architecture Integration showing how securit
 <tr>
 <td valign="top">
 
-### 35. TOGAF Requirements Management
+### 36. TOGAF Requirements Management
 
 A continuous process that captures, validates, prioritizes, manages, and governs architecture requirements across all ADM phases to ensure alignment with business objectives and solution delivery.
 


### PR DESCRIPTION
Adds README section 21 "TOGAF Architecture Partitioning" and image `docs/diagrams/architecture/architecture-partitioning.png`. Placed after Architecture Metamodel (20). Sections 21–35 renumbered to 22–36.

---
_Generated by [Claude Code](https://claude.ai/code/session_015szFF7Lf7ja22irQgzWC6E)_