### PR TITLE
Improve categorised index visibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,10 @@ A free visual library of TOGAF architecture concepts, clear, simplified diagrams
 - `README.md`: repository overview for GitHub.
 - `index.md`: GitHub Pages landing page.
 
-## Diagrams
+## Browse by Category
 
 <details>
-<summary><strong>Browse by category</strong></summary>
+<summary>Click to expand</summary>
 
 ### ADM & Lifecycle
 - [TOGAF ADM End-to-End Reference Map](#1-togaf-adm-end-to-end-reference-map)
@@ -91,6 +91,8 @@ A free visual library of TOGAF architecture concepts, clear, simplified diagrams
 - [TOGAF Security Architecture Integration](#39-togaf-security-architecture-integration)
 
 </details>
+
+## Diagrams
 
 ### 1. TOGAF ADM End-to-End Reference Map
 


### PR DESCRIPTION
Promotes the categorised index from an inline `<details>` label to a proper `## Browse by Category` heading so it appears in GitHub's page outline panel and is immediately visible when scanning the README. Restores `## Diagrams` heading above section 1.

---
_Generated by [Claude Code](https://claude.ai/code/session_015szFF7Lf7ja22irQgzWC6E)_