### PR TITLE
SEO: improve alt tags batch 1/9 - ADM and Phase D/E thumbnails

### DIFF
--- a/index.html
+++ b/index.html
@@ -360,7 +360,7 @@
     <div class="card-grid">
 
       <a href="https://github.com/nelsambrose/togaf-diagrams#1-togaf-adm-end-to-end-reference-map" class="card">
-        <img class="card-thumb" src="docs/diagrams/adm/togaf-adm-end-to-end-architecture.png" alt="TOGAF ADM End-to-End Reference Map" loading="lazy">
+        <img class="card-thumb" src="docs/diagrams/adm/togaf-adm-end-to-end-architecture.png" alt="TOGAF ADM End-to-End Architecture Diagram - complete view of all phases with inputs outputs and cross-phase dependencies" loading="lazy">
         <div class="card-body">
           <div class="card-title">ADM End-to-End Reference Map</div>
           <div class="card-desc">Horizontal swimlane mapping all ADM phases with inputs, outputs, and cross-phase dependencies.</div>
@@ -368,7 +368,7 @@
       </a>
 
       <a href="https://github.com/nelsambrose/togaf-diagrams#2-togaf-adm-cycle" class="card">
-        <img class="card-thumb" src="docs/diagrams/adm/togaf-adm-cycle-v2.png" alt="TOGAF ADM Cycle" loading="lazy">
+        <img class="card-thumb" src="docs/diagrams/adm/togaf-adm-cycle-v2.png" alt="TOGAF ADM Cycle Diagram - Architecture Development Method phases A through H with central Requirements Management" loading="lazy">
         <div class="card-body">
           <div class="card-title">ADM Cycle</div>
           <div class="card-desc">Circular flow of ADM phases from Preliminary through H around a central Requirements Management core.</div>
@@ -376,7 +376,7 @@
       </a>
 
       <a href="https://github.com/nelsambrose/togaf-diagrams#10-togaf-architecture-vision" class="card">
-        <img class="card-thumb" src="docs/diagrams/adm/togaf-architecture-vision.png" alt="TOGAF Architecture Vision" loading="lazy">
+        <img class="card-thumb" src="docs/diagrams/adm/togaf-architecture-vision.png" alt="TOGAF Architecture Vision Diagram - Phase A - defining scope stakeholders and high-level target architecture" loading="lazy">
         <div class="card-body">
           <div class="card-title">Architecture Vision (Phase A)</div>
           <div class="card-desc">High-level aspirational target architecture, stakeholder alignment, and transformation objectives.</div>
@@ -384,7 +384,7 @@
       </a>
 
       <a href="https://github.com/nelsambrose/togaf-diagrams#d-togaf-technology-architecture" class="card">
-        <img class="card-thumb" src="docs/diagrams/technology/togaf-phase-d-technology-architecture.png" alt="TOGAF Technology Architecture" loading="lazy">
+        <img class="card-thumb" src="docs/diagrams/technology/togaf-phase-d-technology-architecture.png" alt="TOGAF Technology Architecture Diagram - Phase D - baseline and target technology platforms and infrastructure" loading="lazy">
         <div class="card-body">
           <div class="card-title">Technology Architecture (Phase D)</div>
           <div class="card-desc">Infrastructure, platform services, integration, security, and operational resilience layers.</div>
@@ -392,7 +392,7 @@
       </a>
 
       <a href="https://github.com/nelsambrose/togaf-diagrams#e-opportunities--solutions" class="card">
-        <img class="card-thumb" src="docs/diagrams/planning/togaf-phase-e-opportunities-solutions-v1.png" alt="Opportunities and Solutions Phase E" loading="lazy">
+        <img class="card-thumb" src="docs/diagrams/planning/togaf-phase-e-opportunities-solutions-v1.png" alt="TOGAF Opportunities and Solutions Diagram - Phase E - identifying work packages and transition architectures" loading="lazy">
         <div class="card-body">
           <div class="card-title">Opportunities &amp; Solutions (Phase E)</div>
           <div class="card-desc">Gap analysis, candidate solutions, work packages, transition architectures, and roadmap planning.</div>


### PR DESCRIPTION
Expands 5 card thumbnail alt tags in index.html using the formula:\n`TOGAF [Concept] Diagram - [Phase] - [Key purpose]`\n\nSkipping the 3 already-indexed images (architecture-partitioning, governance-repository, phase-g-implementation-governance).\n\n**Changed:**\n- adm-end-to-end-architecture\n- adm-cycle\n- architecture-vision\n- phase-d-technology-architecture\n- phase-e-opportunities-solutions

---
_Generated by [Claude Code](https://claude.ai/code/session_01WN2aqMdwDJwRbCsk6FwnKL)_