### PR TITLE
SEO: improve alt tags batch 9/9 - final thumbnails and README Phase E/F/H fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -851,7 +851,7 @@ A Phase E diagram illustrating gap analysis, candidate solutions, work packages,
 </tr>
 <tr>
 <td align="center">
-  <img src="docs/diagrams/planning/togaf-phase-e-opportunities-solutions-v1.png" alt="Phase E diagram showing gap analysis, candidate solutions, work packages, transition architectures, and roadmap planning steps" width="90%"><br>
+  <img src="docs/diagrams/planning/togaf-phase-e-opportunities-solutions-v1.png" alt="TOGAF Opportunities and Solutions Diagram - Phase E - gap analysis candidate solutions work packages and roadmap planning" width="90%"><br>
   <em>Opportunities & Solutions</em>
 </td>
 </tr>
@@ -869,7 +869,7 @@ A TOGAF Phase F diagram illustrating implementation sequencing, migration planni
 </tr>
 <tr>
 <td align="center">
-  <img src="docs/diagrams/planning/togaf-phase-f-migration-planning.png" alt="Phase F diagram showing implementation sequencing, migration planning, dependency management, and governance alignment toward target architecture" width="90%"><br>
+  <img src="docs/diagrams/planning/togaf-phase-f-migration-planning.png" alt="TOGAF Migration Planning Diagram - Phase F - implementation sequencing dependency management and governance alignment" width="90%"><br>
   <em>Migration Planning</em>
 </td>
 </tr>
@@ -905,7 +905,7 @@ A TOGAF Phase H diagram illustrating change assessment, governance decisioning, 
 </tr>
 <tr>
 <td align="center">
-  <img src="docs/diagrams/governance/togaf-phase-h-architecture-change-management.png" alt="Phase H diagram showing change assessment, governance decisioning, architecture evolution, and re-initiation of the ADM lifecycle" width="90%"><br>
+  <img src="docs/diagrams/governance/togaf-phase-h-architecture-change-management.png" alt="TOGAF Architecture Change Management Diagram - Phase H - change assessment governance decisioning and ADM re-initiation" width="90%"><br>
   <em>TOGAF Architecture Change Management</em>
 </td>
 </tr>

--- a/index.html
+++ b/index.html
@@ -764,7 +764,7 @@
       </a>
 
       <a href="https://github.com/nelsambrose/togaf-diagrams#26-togaf-architecture-building-blocks-abbs" class="card">
-        <img class="card-thumb" src="docs/diagrams/building-blocks/togaf-architecture-building-blocks.png" alt="TOGAF Architecture Building Blocks" loading="lazy">
+        <img class="card-thumb" src="docs/diagrams/building-blocks/togaf-architecture-building-blocks.png" alt="TOGAF Architecture Building Blocks Diagram - reusable components capturing architecture requirements and directing solution development" loading="lazy">
         <div class="card-body">
           <div class="card-title">Architecture Building Blocks (ABBs)</div>
           <div class="card-desc">Reusable logical capabilities, standards, and services guiding the realization of Solution Building Blocks.</div>
@@ -784,7 +784,7 @@
     <div class="card-grid">
 
       <a href="https://github.com/nelsambrose/togaf-diagrams#39-togaf-security-architecture-integration" class="card">
-        <img class="card-thumb" src="docs/diagrams/security/togaf-security-architecture-integration.png" alt="TOGAF Security Architecture Integration" loading="lazy">
+        <img class="card-thumb" src="docs/diagrams/security/togaf-security-architecture-integration.png" alt="TOGAF Security Architecture Integration Diagram - embedding security requirements and controls across all ADM phases" loading="lazy">
         <div class="card-body">
           <div class="card-title">Security Architecture Integration</div>
           <div class="card-desc">How security controls, governance, compliance, resilience, and risk management are embedded across all architecture domains.</div>


### PR DESCRIPTION
Final alt tag batch.\n\n**index.html card thumbnails (2):**\n- architecture-building-blocks\n- security-architecture-integration\n\n**README.md full-size image fixes (3):** Phase E, F, H entries were missing the TOGAF prefix — corrected to match the standard formula.\n\nAll 3 protected images (architecture-partitioning, governance-repository, phase-g-implementation-governance) left unchanged throughout.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WN2aqMdwDJwRbCsk6FwnKL)_