### PR TITLE
SEO: keyword-research refinements to 4 key diagram alt tags

### DIFF
--- a/index.html
+++ b/index.html
@@ -368,7 +368,7 @@
       </a>
 
       <a href="https://github.com/nelsambrose/togaf-diagrams#2-togaf-adm-cycle" class="card">
-        <img class="card-thumb" src="docs/diagrams/adm/togaf-adm-cycle-v2.png" alt="TOGAF ADM Cycle Diagram - Architecture Development Method phases A through H with central Requirements Management" loading="lazy">
+        <img class="card-thumb" src="docs/diagrams/adm/togaf-adm-cycle-v2.png" alt="TOGAF ADM Cycle Diagram - Architecture Development Method ADM phases A through H with central Requirements Management" loading="lazy">
         <div class="card-body">
           <div class="card-title">ADM Cycle</div>
           <div class="card-desc">Circular flow of ADM phases from Preliminary through H around a central Requirements Management core.</div>
@@ -580,7 +580,7 @@
     <div class="card-grid">
 
       <a href="https://github.com/nelsambrose/togaf-diagrams#8-architecture-governance-model" class="card">
-        <img class="card-thumb" src="docs/diagrams/governance/togaf-phase-a-architecture-governance-model-v2.png" alt="TOGAF Architecture Governance Model Diagram - Phase A - oversight structures compliance boards and accountability flows" loading="lazy">
+        <img class="card-thumb" src="docs/diagrams/governance/togaf-phase-a-architecture-governance-model-v2.png" alt="TOGAF Architecture Governance Framework Diagram - oversight structures compliance boards accountability flows and governance model" loading="lazy">
         <div class="card-body">
           <div class="card-title">Architecture Governance Model</div>
           <div class="card-desc">Layered governance showing oversight structures, compliance review boards, and accountability flows.</div>
@@ -652,7 +652,7 @@
       </a>
 
       <a href="https://github.com/nelsambrose/togaf-diagrams#40-togaf-requirements-management" class="card">
-        <img class="card-thumb" src="docs/diagrams/governance/togaf-requirements-management.png" alt="TOGAF Requirements Management Diagram - central ADM process for storing managing and feeding architecture requirements" loading="lazy">
+        <img class="card-thumb" src="docs/diagrams/governance/togaf-requirements-management.png" alt="TOGAF ADM Architecture Requirements Management Diagram - central process for storing managing and feeding architecture requirements across phases" loading="lazy">
         <div class="card-body">
           <div class="card-title">Requirements Management</div>
           <div class="card-desc">Continuous process of capturing, validating, prioritising, and governing architecture requirements across all ADM phases.</div>
@@ -740,7 +740,7 @@
       </a>
 
       <a href="https://github.com/nelsambrose/togaf-diagrams#19-togaf-capability-based-planning" class="card">
-        <img class="card-thumb" src="docs/diagrams/architecture/togaf-capability-based-planning.png" alt="TOGAF Capability-Based Planning Diagram - aligning business capabilities to strategy investment and ADM planning" loading="lazy">
+        <img class="card-thumb" src="docs/diagrams/architecture/togaf-capability-based-planning.png" alt="TOGAF Capability-Based Planning Diagram - business capability planning aligned to strategy investment and ADM transformation" loading="lazy">
         <div class="card-body">
           <div class="card-title">Capability-Based Planning</div>
           <div class="card-desc">How enterprise capabilities are identified, assessed, prioritised, and roadmapped to support strategic transformation.</div>


### PR DESCRIPTION
Refines 4 alt tags based on actual search term analysis — adjusting phrasing to match what people commonly search for.\n\n- **adm-cycle**: added "ADM phases" alongside "ADM cycle" (both terms searched heavily)\n- **requirements-management**: aligned to official "ADM Architecture Requirements Management" term\n- **architecture-governance-model**: added "governance framework" (dominant search phrase)\n- **capability-based-planning**: added "business capability planning" (TOGAF 10 alternate term)\n\nAll 3 protected images unchanged.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WN2aqMdwDJwRbCsk6FwnKL)_