### PR TITLE
SEO: improve GitHub Pages title and meta description

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>TOGAF Diagrams Library — Free Visual Reference for TOGAF 10</title>
-  <meta name="description" content="A free visual library of TOGAF 10 enterprise architecture diagrams. Browse 40+ clear, simplified visuals covering the ADM lifecycle, governance, capability planning, stakeholder management, compliance, risk, and more.">
+  <title>TOGAF Diagrams — Free TOGAF 10 Enterprise Architecture &amp; ADM Diagram Library</title>
+  <meta name="description" content="Free TOGAF 10 enterprise architecture diagrams — ADM lifecycle, governance, capability planning, compliance and risk. 40+ clear, simplified visuals.">
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 


### PR DESCRIPTION
Improves the two most important on-page SEO elements for the GitHub Pages site.\n\n**Title** (before → after):\n- `TOGAF Diagrams Library — Free Visual Reference for TOGAF 10`\n- `TOGAF Diagrams — Free TOGAF 10 Enterprise Architecture & ADM Diagram Library`\n\n**Meta description** (before → after):\n- 219 chars (Google truncates at ~155) → 150 chars\n- `Free TOGAF 10 enterprise architecture diagrams — ADM lifecycle, governance, capability planning, compliance and risk. 40+ clear, simplified visuals.`

---
_Generated by [Claude Code](https://claude.ai/code/session_01WN2aqMdwDJwRbCsk6FwnKL)_