### PR TITLE
SEO: add TOGAF prefix to card titles batch 1/9

### DIFF
--- a/index.html
+++ b/index.html
@@ -362,7 +362,7 @@
       <a href="https://github.com/nelsambrose/togaf-diagrams#1-togaf-adm-end-to-end-reference-map" class="card">
         <img class="card-thumb" src="docs/diagrams/adm/togaf-adm-end-to-end-architecture.png" alt="TOGAF ADM End-to-End Architecture Diagram - complete view of all phases with inputs outputs and cross-phase dependencies" loading="lazy">
         <div class="card-body">
-          <div class="card-title">ADM End-to-End Reference Map</div>
+          <div class="card-title">TOGAF ADM End-to-End Reference Map</div>
           <div class="card-desc">Horizontal swimlane mapping all ADM phases with inputs, outputs, and cross-phase dependencies.</div>
         </div>
       </a>
@@ -370,7 +370,7 @@
       <a href="https://github.com/nelsambrose/togaf-diagrams#2-togaf-adm-cycle" class="card">
         <img class="card-thumb" src="docs/diagrams/adm/togaf-adm-cycle-v2.png" alt="TOGAF ADM Cycle Diagram - Architecture Development Method ADM phases A through H with central Requirements Management" loading="lazy">
         <div class="card-body">
-          <div class="card-title">ADM Cycle</div>
+          <div class="card-title">TOGAF ADM Cycle</div>
           <div class="card-desc">Circular flow of ADM phases from Preliminary through H around a central Requirements Management core.</div>
         </div>
       </a>
@@ -378,7 +378,7 @@
       <a href="https://github.com/nelsambrose/togaf-diagrams#10-togaf-architecture-vision" class="card">
         <img class="card-thumb" src="docs/diagrams/adm/togaf-architecture-vision.png" alt="TOGAF Architecture Vision Diagram - Phase A - defining scope stakeholders and high-level target architecture" loading="lazy">
         <div class="card-body">
-          <div class="card-title">Architecture Vision (Phase A)</div>
+          <div class="card-title">TOGAF Architecture Vision (Phase A)</div>
           <div class="card-desc">High-level aspirational target architecture, stakeholder alignment, and transformation objectives.</div>
         </div>
       </a>
@@ -386,7 +386,7 @@
       <a href="https://github.com/nelsambrose/togaf-diagrams#d-togaf-technology-architecture" class="card">
         <img class="card-thumb" src="docs/diagrams/technology/togaf-phase-d-technology-architecture.png" alt="TOGAF Technology Architecture Diagram - Phase D - baseline and target technology platforms and infrastructure" loading="lazy">
         <div class="card-body">
-          <div class="card-title">Technology Architecture (Phase D)</div>
+          <div class="card-title">TOGAF Technology Architecture (Phase D)</div>
           <div class="card-desc">Infrastructure, platform services, integration, security, and operational resilience layers.</div>
         </div>
       </a>
@@ -394,7 +394,7 @@
       <a href="https://github.com/nelsambrose/togaf-diagrams#e-opportunities--solutions" class="card">
         <img class="card-thumb" src="docs/diagrams/planning/togaf-phase-e-opportunities-solutions-v1.png" alt="TOGAF Opportunities and Solutions Diagram - Phase E - identifying work packages and transition architectures" loading="lazy">
         <div class="card-body">
-          <div class="card-title">Opportunities &amp; Solutions (Phase E)</div>
+          <div class="card-title">TOGAF Opportunities &amp; Solutions (Phase E)</div>
           <div class="card-desc">Gap analysis, candidate solutions, work packages, transition architectures, and roadmap planning.</div>
         </div>
       </a>


### PR DESCRIPTION
Adds "TOGAF" prefix to 5 card title visible text elements in index.html.\n\n- ADM End-to-End Reference Map\n- ADM Cycle\n- Architecture Vision (Phase A)\n- Technology Architecture (Phase D)\n- Opportunities & Solutions (Phase E)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WN2aqMdwDJwRbCsk6FwnKL)_