### PR TITLE
SEO: add TOGAF prefix to card titles batch 5/9

### DIFF
--- a/index.html
+++ b/index.html
@@ -546,7 +546,7 @@
       <a href="https://github.com/nelsambrose/togaf-diagrams#25-togaf-reference-architectures" class="card">
         <img class="card-thumb" src="docs/diagrams/repository/togaf-reference-architectures.png" alt="TOGAF Reference Architectures Diagram - reusable architecture models standards and patterns for enterprise reuse" loading="lazy">
         <div class="card-body">
-          <div class="card-title">Reference Architectures</div>
+          <div class="card-title">TOGAF Reference Architectures</div>
           <div class="card-desc">Reusable architecture models, standards, patterns, and implementation guidance for solution delivery.</div>
         </div>
       </a>
@@ -554,7 +554,7 @@
       <a href="https://github.com/nelsambrose/togaf-diagrams#28-standards-information-base" class="card">
         <img class="card-thumb" src="docs/diagrams/repository/togaf-standards-information-base.png" alt="TOGAF Standards Information Base Diagram - approved standards products and services for technology selection" loading="lazy">
         <div class="card-body">
-          <div class="card-title">Standards Information Base</div>
+          <div class="card-title">TOGAF Standards Information Base</div>
           <div class="card-desc">Approved enterprise standards, technology policies, security controls, and compliance requirements.</div>
         </div>
       </a>
@@ -562,7 +562,7 @@
       <a href="https://github.com/nelsambrose/togaf-diagrams#29-togaf-governance-log" class="card">
         <img class="card-thumb" src="docs/diagrams/repository/togaf-governance-log.png" alt="TOGAF Governance Log Diagram - recording governance decisions dispensations and compliance assessments" loading="lazy">
         <div class="card-body">
-          <div class="card-title">Governance Log</div>
+          <div class="card-title">TOGAF Governance Log</div>
           <div class="card-desc">Architecture decisions, compliance activities, risk management, audit traceability, and continuous governance evolution.</div>
         </div>
       </a>
@@ -582,7 +582,7 @@
       <a href="https://github.com/nelsambrose/togaf-diagrams#8-architecture-governance-model" class="card">
         <img class="card-thumb" src="docs/diagrams/governance/togaf-phase-a-architecture-governance-model-v2.png" alt="TOGAF Architecture Governance Framework Diagram - oversight structures compliance boards accountability flows and governance model" loading="lazy">
         <div class="card-body">
-          <div class="card-title">Architecture Governance Model</div>
+          <div class="card-title">TOGAF Architecture Governance Model</div>
           <div class="card-desc">Layered governance showing oversight structures, compliance review boards, and accountability flows.</div>
         </div>
       </a>
@@ -590,7 +590,7 @@
       <a href="https://github.com/nelsambrose/togaf-diagrams#30-togaf-architecture-principles" class="card">
         <img class="card-thumb" src="docs/diagrams/governance/togaf-architecture-principles.png" alt="TOGAF Architecture Principles Diagram - guiding statements for making architecture decisions across the enterprise" loading="lazy">
         <div class="card-body">
-          <div class="card-title">Architecture Principles</div>
+          <div class="card-title">TOGAF Architecture Principles</div>
           <div class="card-desc">Business, data, application, technology, and governance principles guiding enterprise decision-making.</div>
         </div>
       </a>


### PR DESCRIPTION
Adds "TOGAF" prefix to 5 card title visible text elements in index.html.\n\n- Reference Architectures\n- Standards Information Base\n- Governance Log\n- Architecture Governance Model\n- Architecture Principles

---
_Generated by [Claude Code](https://claude.ai/code/session_01WN2aqMdwDJwRbCsk6FwnKL)_