### PR TITLE
SEO: add TOGAF prefix to card titles batch 6/9

### DIFF
--- a/index.html
+++ b/index.html
@@ -598,7 +598,7 @@
       <a href="https://github.com/nelsambrose/togaf-diagrams#32-togaf-architecture-contracts" class="card">
         <img class="card-thumb" src="docs/diagrams/governance/togaf-architecture-contracts.png" alt="TOGAF Architecture Contracts Diagram - joint agreements governing architecture delivery and change between stakeholders" loading="lazy">
         <div class="card-body">
-          <div class="card-title">Architecture Contracts</div>
+          <div class="card-title">TOGAF Architecture Contracts</div>
           <div class="card-desc">Governance agreements, compliance obligations, responsibilities, and implementation accountability.</div>
         </div>
       </a>
@@ -606,7 +606,7 @@
       <a href="https://github.com/nelsambrose/togaf-diagrams#33-togaf-architecture-compliance-reviews" class="card">
         <img class="card-thumb" src="docs/diagrams/governance/togaf-architecture-compliance-reviews.png" alt="TOGAF Architecture Compliance Reviews Diagram - formal assessment of projects against architecture standards and principles" loading="lazy">
         <div class="card-body">
-          <div class="card-title">Architecture Compliance Reviews</div>
+          <div class="card-title">TOGAF Architecture Compliance Reviews</div>
           <div class="card-desc">Assessment of solutions against architecture principles, standards, governance requirements, and risks.</div>
         </div>
       </a>
@@ -614,7 +614,7 @@
       <a href="https://github.com/nelsambrose/togaf-diagrams#34-togaf-compliance-assessment" class="card">
         <img class="card-thumb" src="docs/diagrams/governance/togaf-compliance-assessment.png" alt="TOGAF Compliance Assessment Diagram - scoring projects against architecture standards from irrelevant to fully conformant" loading="lazy">
         <div class="card-body">
-          <div class="card-title">Compliance Assessment</div>
+          <div class="card-title">TOGAF Compliance Assessment</div>
           <div class="card-desc">Governance validation, standards alignment, and delivery oversight supporting controlled enterprise transformation.</div>
         </div>
       </a>
@@ -622,7 +622,7 @@
       <a href="https://github.com/nelsambrose/togaf-diagrams#35-togaf-governance-repository" class="card">
         <img class="card-thumb" src="docs/diagrams/governance/togaf-governance-repository.png" alt="TOGAF Governance Repository" loading="lazy">
         <div class="card-body">
-          <div class="card-title">Governance Repository</div>
+          <div class="card-title">TOGAF Governance Repository</div>
           <div class="card-desc">Centralised store of architecture decisions, compliance records, policies, audit evidence, and governance outcomes.</div>
         </div>
       </a>
@@ -630,7 +630,7 @@
       <a href="https://github.com/nelsambrose/togaf-diagrams#36-togaf-architecture-decisions--traceability" class="card">
         <img class="card-thumb" src="docs/diagrams/governance/togaf-architecture-decisions-traceability.png" alt="TOGAF Architecture Decisions and Traceability Diagram - linking decisions to requirements principles and stakeholder concerns" loading="lazy">
         <div class="card-body">
-          <div class="card-title">Architecture Decisions &amp; Traceability</div>
+          <div class="card-title">TOGAF Architecture Decisions &amp; Traceability</div>
           <div class="card-desc">How architecture decisions, governance approvals, rationale, and dependencies are managed across transformation initiatives.</div>
         </div>
       </a>


### PR DESCRIPTION
Adds "TOGAF" prefix to 5 card title visible text elements in index.html.\n\n- Architecture Contracts\n- Architecture Compliance Reviews\n- Compliance Assessment\n- Governance Repository\n- Architecture Decisions & Traceability

---
_Generated by [Claude Code](https://claude.ai/code/session_01WN2aqMdwDJwRbCsk6FwnKL)_