### PR TITLE
SEO: add TOGAF prefix to card titles batch 9/9

### DIFF
--- a/index.html
+++ b/index.html
@@ -742,7 +742,7 @@
       <a href="https://github.com/nelsambrose/togaf-diagrams#19-togaf-capability-based-planning" class="card">
         <img class="card-thumb" src="docs/diagrams/architecture/togaf-capability-based-planning.png" alt="TOGAF Capability-Based Planning Diagram - business capability planning aligned to strategy investment and ADM transformation" loading="lazy">
         <div class="card-body">
-          <div class="card-title">Capability-Based Planning</div>
+          <div class="card-title">TOGAF Capability-Based Planning</div>
           <div class="card-desc">How enterprise capabilities are identified, assessed, prioritised, and roadmapped to support strategic transformation.</div>
         </div>
       </a>
@@ -750,7 +750,7 @@
       <a href="https://github.com/nelsambrose/togaf-diagrams#31-togaf-architecture-capability" class="card">
         <img class="card-thumb" src="docs/diagrams/capability/togaf-architecture-capability.png" alt="TOGAF Architecture Capability Diagram - skills roles and organizational structures for enterprise architecture practice" loading="lazy">
         <div class="card-body">
-          <div class="card-title">Architecture Capability</div>
+          <div class="card-title">TOGAF Architecture Capability</div>
           <div class="card-desc">Governance structures, people, processes, tools, and maturity practices for enterprise architecture.</div>
         </div>
       </a>
@@ -758,7 +758,7 @@
       <a href="https://github.com/nelsambrose/togaf-diagrams#6-architecture-building-blocks-vs-solution-building-blocks" class="card">
         <img class="card-thumb" src="docs/diagrams/building-blocks/togaf-phase-a-architecture-building-blocks-vs-solution-building-blocks-v2.png" alt="TOGAF Architecture Building Blocks vs Solution Building Blocks Diagram - Phase A - abstract architecture versus vendor-specific implementations" loading="lazy">
         <div class="card-body">
-          <div class="card-title">Architecture Building Blocks vs. Solution Building Blocks</div>
+          <div class="card-title">TOGAF Architecture Building Blocks vs. Solution Building Blocks</div>
           <div class="card-desc">Side-by-side comparison of abstract enterprise architecture building blocks against vendor-specific solution building blocks.</div>
         </div>
       </a>
@@ -766,7 +766,7 @@
       <a href="https://github.com/nelsambrose/togaf-diagrams#26-togaf-architecture-building-blocks-abbs" class="card">
         <img class="card-thumb" src="docs/diagrams/building-blocks/togaf-architecture-building-blocks.png" alt="TOGAF Architecture Building Blocks Diagram - reusable components capturing architecture requirements and directing solution development" loading="lazy">
         <div class="card-body">
-          <div class="card-title">Architecture Building Blocks (ABBs)</div>
+          <div class="card-title">TOGAF Architecture Building Blocks (ABBs)</div>
           <div class="card-desc">Reusable logical capabilities, standards, and services guiding the realization of Solution Building Blocks.</div>
         </div>
       </a>
@@ -786,7 +786,7 @@
       <a href="https://github.com/nelsambrose/togaf-diagrams#39-togaf-security-architecture-integration" class="card">
         <img class="card-thumb" src="docs/diagrams/security/togaf-security-architecture-integration.png" alt="TOGAF Security Architecture Integration Diagram - embedding security requirements and controls across all ADM phases" loading="lazy">
         <div class="card-body">
-          <div class="card-title">Security Architecture Integration</div>
+          <div class="card-title">TOGAF Security Architecture Integration</div>
           <div class="card-desc">How security controls, governance, compliance, resilience, and risk management are embedded across all architecture domains.</div>
         </div>
       </a>


### PR DESCRIPTION
Final batch — adds "TOGAF" prefix to the last 5 card title visible text elements in index.html.\n\n- Capability-Based Planning\n- Architecture Capability\n- Architecture Building Blocks vs. Solution Building Blocks\n- Architecture Building Blocks (ABBs)\n- Security Architecture Integration\n\nAll 45 card titles now include the "TOGAF" prefix as visible text on the landing page.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WN2aqMdwDJwRbCsk6FwnKL)_